### PR TITLE
Fix iterating over left ancestors when updating height

### DIFF
--- a/src/line-top-index.js
+++ b/src/line-top-index.js
@@ -17,9 +17,14 @@ export default class LineTopIndex {
   insertBlock (row, height) {
     let node = this.iterator.insertBlockEnd(row)
     node.distanceFromLeftAncestor.pixels += height
-    while (node.parent && node.parent.left === node) {
-      node = node.parent
-      node.distanceFromLeftAncestor.pixels += height
+
+    let parent
+    while (parent = node.parent) {
+      if (parent.left === node) {
+        parent.distanceFromLeftAncestor.pixels += height
+      }
+
+      node = parent
     }
   }
 

--- a/src/line-top-index.js
+++ b/src/line-top-index.js
@@ -17,14 +17,12 @@ export default class LineTopIndex {
   insertBlock (row, height) {
     let node = this.iterator.insertBlockEnd(row)
     node.distanceFromLeftAncestor.pixels += height
-
-    let parent
-    while (parent = node.parent) {
-      if (parent.left === node) {
-        parent.distanceFromLeftAncestor.pixels += height
+    while (node.parent) {
+      if (node.parent.left === node) {
+        node.parent.distanceFromLeftAncestor.pixels += height
       }
 
-      node = parent
+      node = node.parent
     }
   }
 


### PR DESCRIPTION
This caused insertions not to be fully propagated to the top, thus not updating nodes upper in the tree with the new distance from their left ancestor. After this commit, randomized tests for insertion are :green_heart: and I think we can probably mark that as completed.

@nathansobo: could you add me to [atom/line-top-index](https://github.com/atom/line-top-index) collaborators, please? 