### PR TITLE
Fix splicing on nodes which contain both inclusive and exclusive blocks

### DIFF
--- a/src/iterator.js
+++ b/src/iterator.js
@@ -16,7 +16,7 @@ export default class Iterator {
     this.setCurrentNode(this.tree.root)
   }
 
-  insertNode (point) {
+  insertNode (point, duplicateNode=false) {
     this.reset()
 
     if (!this.currentNode) {
@@ -33,7 +33,7 @@ export default class Iterator {
         } else {
           return this.insertLeftChild(point)
         }
-      } else if (comparison === 0) {
+      } else if (comparison === 0 && !duplicateNode) {
         return this.currentNode
       } else { // comparison > 0
         if (this.currentNode.right) {

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -16,7 +16,7 @@ export default class Iterator {
     this.setCurrentNode(this.tree.root)
   }
 
-  insertNode (point, duplicateNode=false) {
+  insertNode (point, matchNodesAtSamePosition=true) {
     this.reset()
 
     if (!this.currentNode) {
@@ -33,7 +33,7 @@ export default class Iterator {
         } else {
           return this.insertLeftChild(point)
         }
-      } else if (comparison === 0 && !duplicateNode) {
+      } else if (comparison === 0 && matchNodesAtSamePosition) {
         return this.currentNode
       } else { // comparison > 0
         if (this.currentNode.right) {

--- a/src/line-top-index.js
+++ b/src/line-top-index.js
@@ -66,8 +66,6 @@ export default class LineTopIndex {
   }
 
   splice (start, oldExtent, newExtent) {
-    if (isZero(oldExtent) && isZero(newExtent)) return
-
     let oldEnd = traverse(start, oldExtent)
     let newEnd = traverse(start, newExtent)
 
@@ -95,12 +93,12 @@ export default class LineTopIndex {
     if (startNode.right) {
       let blockIdsToMove = new Set
       this.collectBlockIdsForSubtree(startNode.right, blockIdsToMove)
-      startNode.right = null
       blockIdsToMove.forEach((id) => {
         endNode.blockIds.add(id)
         endNode.blockHeight += this.blockHeightsById[id]
         this.blockEndNodesById[id] = endNode
       })
+      startNode.right = null
     }
 
     endNode.distanceFromLeftAncestor.point = newEnd

--- a/src/line-top-index.js
+++ b/src/line-top-index.js
@@ -70,8 +70,8 @@ export default class LineTopIndex {
     let newEnd = traverse(start, newExtent)
 
     let isInsertion = isZero(oldExtent)
-    let startNode = this.iterator.insertNode(start, false)
-    let endNode = this.iterator.insertNode(oldEnd, isInsertion)
+    let startNode = this.iterator.insertNode(start)
+    let endNode = this.iterator.insertNode(oldEnd, !isInsertion)
 
     startNode.priority = -1
     this.bubbleNodeUp(startNode)

--- a/test/line-top-index.test.js
+++ b/test/line-top-index.test.js
@@ -9,7 +9,7 @@ describe('LineTopIndex', () => {
   it('determines line heights correctly after randomized insertions, removals, and splices', function () {
     this.timeout(Infinity)
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 7000; i++) {
       let seed = Date.now()
       let random = new Random(seed)
 
@@ -19,7 +19,7 @@ describe('LineTopIndex', () => {
       let actualIndex = new LineTopIndex({seed, defaultLineHeight, maxRow})
       idCounter = 1
 
-      for (let j = 0; j < 4; j++) {
+      for (let j = 0; j < 900; j++) {
         let k = random(10)
         if (k < 3) {
           performInsertion(random, actualIndex, referenceIndex)


### PR DESCRIPTION
This fixes an issue where a node could contain both exclusive and inclusive nodes. 

With the previous approach, when the start node coincided with the end node, we basically moved both to the new end position, thereby causing both inclusive and exclusive markers to be moved. This PR changes it so that we create a new node at the `oldEnd` when there is an insertion, so that the two kinds of markers can be moved independently.

I am opening a PR because it's the first big change I make to this code and I'd love to have another pair of :eyes: before committing to master.

/cc: @nathansobo 